### PR TITLE
Update links for GitHub org transfer

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
   - name: ❓ Usage question
-    url: https://github.com/pangeo-data/xbatcher/discussions
+    url: https://github.com/xarray-contrib/xbatcher/discussions
     about: |
       Ask questions and discuss with other community members here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-All contributors and maintainers must abide by the [Pangeo Code of Conduct](https://github.com/pangeo-data/governance/blob/master/conduct/code_of_conduct.md).
+All contributors and maintainers must abide by the [xarray-contrib organization Code of Conduct](https://github.com/xarray-contrib/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,11 @@ such as Keras_. View the |docs| for more info.
 .. _Keras: https://keras.io/
 
 
-.. |Build Status| image:: https://github.com/pangeo-data/xbatcher/workflows/CI/badge.svg
-   :target: https://github.com/pangeo-data/xbatcher/actions
+.. |Build Status| image:: https://github.com/xarray-contrib/xbatcher/workflows/CI/badge.svg
+   :target: https://github.com/xarray-contrib/xbatcher/actions
    :alt: github actions build status
-.. |codecov| image:: https://codecov.io/gh/pangeo-data/xbatcher/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/pangeo-data/xbatcher
+.. |codecov| image:: https://codecov.io/gh/xarray-contrib/xbatcher/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/xarray-contrib/xbatcher
    :alt: code coverage
 .. |docs| image:: http://readthedocs.org/projects/xbatcher/badge/?version=latest
    :target: http://xbatcher.readthedocs.org/en/latest/?badge=latest
@@ -24,5 +24,5 @@ such as Keras_. View the |docs| for more info.
    :target: https://pypi.python.org/pypi/xbatcher
    :alt: pypi
 .. |license| image:: https://img.shields.io/github/license/mashape/apistatus.svg
-   :target: https://github.com/pangeo-data/xbatcher
+   :target: https://github.com/xarray-contrib/xbatcher
    :alt: license

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -50,7 +50,7 @@
   "install_timeout": 600,
 
   // the base URL to show a commit for the project.
-  // "show_commit_url": "http://github.com/pangeo-data/xbatcher/commit/",
+  // "show_commit_url": "http://github.com/xarray-contrib/xbatcher/commit/",
 
   // The Pythons you'd like to test against.  If not provided, defaults
   // to the current version of Python used to run `asv`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,7 +74,7 @@ autodoc_mock_imports = ['torch', 'tensorflow']
 
 # link to github issues
 extlinks = {
-    'issue': ('https://github.com/pangeo-data/xbatcher/issues/%s', 'GH')
+    'issue': ('https://github.com/xarray-contrib/xbatcher/issues/%s', 'GH')
 }
 
 # sphinx-copybutton configurations (from https://github.com/pydata/xarray/blob/main/doc/conf.py)

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -15,7 +15,7 @@ Bug reports and feature requests
 ================================
 
 To report bugs or request new features, head over to the `xbatcher repository
-<https://github.com/pangeo-data/xbatcher/issues>`_.
+<https://github.com/xarray-contrib/xbatcher/issues>`_.
 
 Contributing code
 ==================
@@ -30,12 +30,12 @@ Forking
 -------
 
 You will need your own fork to work on the code. Go to the `xbatcher project
-page <https://github.com/pangeo-data/xbatcher>`_ and hit the ``Fork`` button.
+page <https://github.com/xarray-contrib/xbatcher>`_ and hit the ``Fork`` button.
 You will need to clone your fork to your machine::
 
     git clone git@github.com:yourusername/xbatcher.git
     cd xbatcher
-    git remote add upstream git@github.com:pangeo-data/xbatcher.git
+    git remote add upstream git@github.com:xarray-contrib/xbatcher.git
 
 This creates the directory ``xbatcher`` and connects your repository to
 the upstream (main project) *xbatcher* repository.
@@ -245,4 +245,4 @@ Continuous integration is done with `GitHub Actions <https://docs.github.com/en/
 
 There is currently 1 workflow configured:
 
-- `main.yaml <https://github.com/pangeo-data/xbatcher/blob/main/.github/workflows/main.yaml>`_ - Run test suite with pytest.
+- `main.yaml <https://github.com/xarray-contrib/xbatcher/blob/main/.github/workflows/main.yaml>`_ - Run test suite with pytest.

--- a/doc/demo.ipynb
+++ b/doc/demo.ipynb
@@ -1564,7 +1564,7 @@
    "source": [
     "## Last batch behavior\n",
     "\n",
-    "If the input ds is not divisible by the specified `input_dims`, the remainder will be discarded instead of having a fractional batch. See https://github.com/pangeo-data/xbatcher/issues/5 for more on this topic."
+    "If the input ds is not divisible by the specified `input_dims`, the remainder will be discarded instead of having a fractional batch. See https://github.com/xarray-contrib/xbatcher/issues/5 for more on this topic."
    ]
   },
   {
@@ -3060,7 +3060,7 @@
    "source": [
     "## What's next?\n",
     "\n",
-    "There are many additional useful features that were yet to be implemented in the context of batch generation for downstream machine learning model training purposes. One of the current efforts is adding a set of data loaders (see [working PR for PyTorch data loader](https://github.com/pangeo-data/xbatcher/pull/25)). \n",
+    "There are many additional useful features that were yet to be implemented in the context of batch generation for downstream machine learning model training purposes. One of the current efforts is to improve the set of data loaders. \n",
     "\n",
     "Additional features of interest can include: \n",
     "\n",
@@ -3073,7 +3073,7 @@
     "4. Handling preprocessing steps. For example, data augmentation, scaling/normalization, outlier detection, etc. \n",
     "\n",
     "\n",
-    "More thoughts on 1. and 2. can be found in [this issue](https://github.com/pangeo-data/xbatcher/issues/30). Interested users are welcomed to comment or submit other issues in GitHub. "
+    "More thoughts on 1. and 2. can be found in [this issue](https://github.com/xarray-contrib/xbatcher/issues/30). Interested users are welcomed to comment or submit other issues in GitHub. "
    ]
   }
  ],

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,7 @@ Or via Conda as::
 
 Or from source as::
 
-    pip install git+https://github.com/pangeo-data/xbatcher.git
+    pip install git+https://github.com/xarray-contrib/xbatcher.git
 
 Basic Usage
 -----------

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ DISTNAME = 'xbatcher'
 LICENSE = 'Apache'
 AUTHOR = 'xbatcher Developers'
 AUTHOR_EMAIL = 'rpa@ldeo.columbia.edu'
-URL = 'https://github.com/pangeo-data/xbatcher'
+URL = 'https://github.com/xarray-contrib/xbatcher'
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
     'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
**Description of proposed changes**

Even though [GitHub sets up redirects for the transferred repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository#whats-transferred-with-a-repository), it will be more clear to have the links directly point to the xarray-contrib org. This PR updates all such links except in the demo and code of conduct, which require larger updates.
