### PR TITLE
Rely on xarray-contrib code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,0 @@
-All contributors and maintainers must abide by the [xarray-contrib organization Code of Conduct](https://github.com/xarray-contrib/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
**Description of proposed changes**

Removes CODE_OF_CONDUCT.md, since GitHub will pick up https://github.com/xarray-contrib/.github/blob/main/CODE_OF_CONDUCT.md.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

Fixes #
