### PR TITLE
Add GitHub button to docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -161,7 +161,11 @@ html_theme = 'pangeo_sphinx_book_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    'repository_url': 'https://github.com/xarray-contrib/xbatcher',
+    'use_repository_button': True,
+    'use_issues_button': True,
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
I landed on the `xbatcher` docs and was interested in checking out the source in GitHub. It wasn't difficult to find the GitHub repo, but did require me do a Google search. This PR adds a GitHub icon to the docs that links directly to the project GitHub repo (see the screenshot below) 

<img width="1552" alt="Screen Shot 2022-09-22 at 12 40 01 PM" src="https://user-images.githubusercontent.com/11656932/191815859-6ef62a36-8f9d-4ad1-bcf4-12bf8c305ce1.png">
