### PR TITLE
TFAccessor and _as_xarray_dataarray update

### DIFF
--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -48,24 +48,26 @@ class KerasAccessor:
         self._obj = xarray_obj
 
     def to_tensor(self):
-        """Convert this DataArray to a torch.Tensor"""
+        """Convert this DataArray to a tensorflow.Tensor"""
         import tensorflow as tf
 
         dataarray = _as_xarray_dataarray(xr_obj=self._obj)
 
         return tf.convert_to_tensor(dataarray.data)
 
-    def to_named_tensor(self):
-        """
-        Convert this DataArray to a torch.Tensor with named dimensions.
+    def to_named_tensor(
+        self,
+    ):  # There does not seem to be a named tensor for tensorflow?
+        pass
 
-        See https://pytorch.org/docs/stable/named_tensor.html
-        """
-        import tensorflow as tf
+        # """
+        # Convert this DataArray to a .Tensor with named dimensions.
+        # """
+        # import tensorflow as tf
 
-        dataarray = _as_xarray_dataarray(xr_obj=self._obj)
+        # dataarray = _as_xarray_dataarray(xr_obj=self._obj)
 
-        return tf.convert_to_tensor(dataarray.data, name=tuple(dataarray.sizes))
+        # return tf.convert_to_tensor(dataarray.data, name=tuple(dataarray.sizes))
 
 
 @xr.register_dataarray_accessor("torch")

--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -1,6 +1,21 @@
+from typing import Union
+
 import xarray as xr
 
 from .generators import BatchGenerator
+
+
+def _as_xarray_dataarray(
+    xr_obj: Union[xr.Dataset, xr.DataArray]
+) -> Union[xr.Dataset, xr.DataArray]:
+    """
+    Convert xarray.Dataset to xarray.DataArray if needed, so that it can
+    be converted into a torch.Tensor object.
+    """
+    if isinstance(xr_obj, xr.Dataset):
+        xr_obj = xr_obj.to_array().squeeze(dim="variable")
+
+    return xr_obj
 
 
 @xr.register_dataarray_accessor("batch")
@@ -32,25 +47,11 @@ class TorchAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
 
-    def _as_xarray_dataarray(self, xr_obj):
-        """
-        Convert xarray.Dataset to xarray.DataArray if needed, so that it can
-        be converted into a torch.Tensor object.
-        """
-        try:
-            # Convert xr.Dataset to xr.DataArray
-            dataarray = xr_obj.to_array().squeeze(dim="variable")
-        except AttributeError:  # 'DataArray' object has no attribute 'to_array'
-            # If object is already an xr.DataArray
-            dataarray = xr_obj
-
-        return dataarray
-
     def to_tensor(self):
         """Convert this DataArray to a torch.Tensor"""
         import torch
 
-        dataarray = self._as_xarray_dataarray(xr_obj=self._obj)
+        dataarray = _as_xarray_dataarray(xr_obj=self._obj)
 
         return torch.tensor(data=dataarray.data)
 
@@ -62,6 +63,6 @@ class TorchAccessor:
         """
         import torch
 
-        dataarray = self._as_xarray_dataarray(xr_obj=self._obj)
+        dataarray = _as_xarray_dataarray(xr_obj=self._obj)
 
         return torch.tensor(data=dataarray.data, names=tuple(dataarray.sizes))

--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -5,9 +5,7 @@ import xarray as xr
 from .generators import BatchGenerator
 
 
-def _as_xarray_dataarray(
-    xr_obj: Union[xr.Dataset, xr.DataArray]
-) -> Union[xr.Dataset, xr.DataArray]:
+def _as_xarray_dataarray(xr_obj: Union[xr.Dataset, xr.DataArray]) -> xr.DataArray:
     """
     Convert xarray.Dataset to xarray.DataArray if needed, so that it can
     be converted into a torch.Tensor object.
@@ -41,9 +39,9 @@ class BatchAccessor:
         return BatchGenerator(self._obj, *args, **kwargs)
 
 
-@xr.register_dataarray_accessor("keras")
-@xr.register_dataset_accessor("keras")
-class KerasAccessor:
+@xr.register_dataarray_accessor("tf")
+@xr.register_dataset_accessor("tf")
+class TFAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
 

--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -55,20 +55,6 @@ class KerasAccessor:
 
         return tf.convert_to_tensor(dataarray.data)
 
-    def to_named_tensor(
-        self,
-    ):  # There does not seem to be a named tensor for tensorflow?
-        pass
-
-        # """
-        # Convert this DataArray to a .Tensor with named dimensions.
-        # """
-        # import tensorflow as tf
-
-        # dataarray = _as_xarray_dataarray(xr_obj=self._obj)
-
-        # return tf.convert_to_tensor(dataarray.data, name=tuple(dataarray.sizes))
-
 
 @xr.register_dataarray_accessor("torch")
 @xr.register_dataset_accessor("torch")

--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -41,6 +41,33 @@ class BatchAccessor:
         return BatchGenerator(self._obj, *args, **kwargs)
 
 
+@xr.register_dataarray_accessor("keras")
+@xr.register_dataset_accessor("keras")
+class KerasAccessor:
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+
+    def to_tensor(self):
+        """Convert this DataArray to a torch.Tensor"""
+        import tensorflow as tf
+
+        dataarray = _as_xarray_dataarray(xr_obj=self._obj)
+
+        return tf.convert_to_tensor(dataarray.data)
+
+    def to_named_tensor(self):
+        """
+        Convert this DataArray to a torch.Tensor with named dimensions.
+
+        See https://pytorch.org/docs/stable/named_tensor.html
+        """
+        import tensorflow as tf
+
+        dataarray = _as_xarray_dataarray(xr_obj=self._obj)
+
+        return tf.convert_to_tensor(dataarray.data, name=tuple(dataarray.sizes))
+
+
 @xr.register_dataarray_accessor("torch")
 @xr.register_dataset_accessor("torch")
 class TorchAccessor:

--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -8,7 +8,7 @@ from .generators import BatchGenerator
 def _as_xarray_dataarray(xr_obj: Union[xr.Dataset, xr.DataArray]) -> xr.DataArray:
     """
     Convert xarray.Dataset to xarray.DataArray if needed, so that it can
-    be converted into a torch.Tensor object.
+    be converted into a Tensor object.
     """
     if isinstance(xr_obj, xr.Dataset):
         xr_obj = xr_obj.to_array().squeeze(dim="variable")

--- a/xbatcher/tests/test_accessors.py
+++ b/xbatcher/tests/test_accessors.py
@@ -72,11 +72,11 @@ def test_batch_accessor_da(sample_ds_3d):
     ],
 )
 def test_tf_to_tensor(sample_ds_3d, foo_var):
-    tensorflow = pytest.importorskip("tensorflow")
+    tf = pytest.importorskip("tensorflow")
 
     foo = sample_ds_3d[foo_var]
     t = foo.tf.to_tensor()
-    assert isinstance(t, tensorflow.Tensor)
+    assert isinstance(t, tf.Tensor)
     assert t.shape == tuple(foo.sizes.values())
 
     foo_array = foo.to_array().squeeze() if hasattr(foo, "to_array") else foo

--- a/xbatcher/tests/test_accessors.py
+++ b/xbatcher/tests/test_accessors.py
@@ -71,6 +71,25 @@ def test_batch_accessor_da(sample_ds_3d):
         ["foo"],  # xr.Dataset
     ],
 )
+def test_keras_to_tensor(sample_ds_3d, foo_var):
+    tensorflow = pytest.importorskip("tensorflow")
+
+    foo = sample_ds_3d[foo_var]
+    t = foo.keras.to_tensor()
+    assert isinstance(t, tensorflow.Tensor)
+    assert t.shape == tuple(foo.sizes.values())
+
+    foo_array = foo.to_array().squeeze() if hasattr(foo, "to_array") else foo
+    np.testing.assert_array_equal(t, foo_array.values)
+
+
+@pytest.mark.parametrize(
+    "foo_var",
+    [
+        "foo",  # xr.DataArray
+        ["foo"],  # xr.Dataset
+    ],
+)
 def test_torch_to_tensor(sample_ds_3d, foo_var):
     torch = pytest.importorskip("torch")
 

--- a/xbatcher/tests/test_accessors.py
+++ b/xbatcher/tests/test_accessors.py
@@ -22,6 +22,30 @@ def sample_ds_3d():
     return ds
 
 
+@pytest.fixture(scope="module")
+def sample_dataArray():
+    return xr.DataArray(np.zeros((2, 4), dtype="i4"), dims=("x", "y"), name="foo")
+
+
+@pytest.fixture(scope="module")
+def sample_Dataset():
+    return xr.Dataset(
+        {
+            "x": xr.DataArray(np.arange(10), dims="x"),
+            "foo": xr.DataArray(np.ones(10, dtype="float"), dims="x"),
+        }
+    )
+
+
+def test_as_xarray_dataarray(sample_dataArray, sample_Dataset):
+    assert isinstance(
+        xbatcher.accessors._as_xarray_dataarray(sample_dataArray), xr.DataArray
+    )
+    assert isinstance(
+        xbatcher.accessors._as_xarray_dataarray(sample_Dataset), xr.DataArray
+    )
+
+
 def test_batch_accessor_ds(sample_ds_3d):
     bg_class = BatchGenerator(sample_ds_3d, input_dims={"x": 5})
     bg_acc = sample_ds_3d.batch.generator(input_dims={"x": 5})

--- a/xbatcher/tests/test_accessors.py
+++ b/xbatcher/tests/test_accessors.py
@@ -71,11 +71,11 @@ def test_batch_accessor_da(sample_ds_3d):
         ["foo"],  # xr.Dataset
     ],
 )
-def test_keras_to_tensor(sample_ds_3d, foo_var):
+def test_tf_to_tensor(sample_ds_3d, foo_var):
     tensorflow = pytest.importorskip("tensorflow")
 
     foo = sample_ds_3d[foo_var]
-    t = foo.keras.to_tensor()
+    t = foo.tf.to_tensor()
     assert isinstance(t, tensorflow.Tensor)
     assert t.shape == tuple(foo.sizes.values())
 


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->
Adds to: https://github.com/xarray-contrib/xbatcher/issues/83#issue-1340867381. Based off changes in PR: https://github.com/xarray-contrib/xbatcher/pull/85. 

- method `_as_xarray_dataarray` moved outside of `TorchAccessor` class. 
- `_as_xarray_dataarray` method modified to use `is_instance` instead of try:except. 
- unit test added to cover `_as_xarray_dataarray`
- Attempt at `KerasAccessor` and corresponding tests. 

