### PR TITLE
basic pluggable cache implementation

### DIFF
--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -111,7 +111,7 @@ class BatchGenerator:
         batch_dims: Dict[Hashable, int] = {},
         concat_input_dims: bool = False,
         preload_batch: bool = True,
-        cache: dict[str, Any] | None = None,
+        cache: Dict[str, Any] | None = None,
         cache_preprocess: Callable | None = None,
     ):
 
@@ -144,7 +144,7 @@ class BatchGenerator:
         if idx < 0:
             idx = list(self._batches)[idx]
 
-        if self.cache and idx in self.cache:
+        if self.cache and self._batch_in_cache(idx):
             return self._get_cached_batch(idx)
 
         if idx in self._batches:
@@ -177,7 +177,11 @@ class BatchGenerator:
 
         return batch
 
-    def _cache_batch(self, idx: int, batch: xr.Dataset):
+    def _batch_in_cache(self, idx: int) -> bool:
+        gkey = f"{idx}/.zgroup"
+        return gkey in self.cache
+
+    def _cache_batch(self, idx: int, batch: xr.Dataset) -> None:
         batch.to_zarr(self.cache, group=str(idx), mode="a")
 
     def _get_cached_batch(self, idx: int) -> xr.Dataset:

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -170,9 +170,9 @@ class BatchGenerator:
         else:
             raise IndexError("list index out of range")
 
+        if self.cache is not None and self.cache_preprocess is not None:
+            batch = self.cache_preprocess(batch)
         if self.cache is not None:
-            if self.cache_preprocess is not None:
-                batch = self.cache_preprocess(batch)
             self._cache_batch(idx, batch)
 
         return batch

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -2,7 +2,7 @@
 
 import itertools
 from collections import OrderedDict
-from typing import Any, Callable, Dict, Hashable, Iterator
+from typing import Any, Callable, Dict, Hashable, Iterator, Optional
 
 import xarray as xr
 
@@ -111,8 +111,8 @@ class BatchGenerator:
         batch_dims: Dict[Hashable, int] = {},
         concat_input_dims: bool = False,
         preload_batch: bool = True,
-        cache: Dict[str, Any] | None = None,
-        cache_preprocess: Callable | None = None,
+        cache: Optional[Dict[str, Any]] = None,
+        cache_preprocess: Optional[Callable] = None,
     ):
 
         self.ds = ds
@@ -178,8 +178,7 @@ class BatchGenerator:
         return batch
 
     def _batch_in_cache(self, idx: int) -> bool:
-        gkey = f"{idx}/.zgroup"
-        return gkey in self.cache
+        return self.cache is not None and f"{idx}/.zgroup" in self.cache
 
     def _cache_batch(self, idx: int, batch: xr.Dataset) -> None:
         batch.to_zarr(self.cache, group=str(idx), mode="a")

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 import numpy as np
 import pytest
@@ -227,7 +227,8 @@ def test_batch_exceptions(sample_ds_1d):
 
 
 def test_batcher_cached_getitem(sample_ds_1d) -> None:
-    cache: dict[str, Any] = {}
+    pytest.importorskip("zarr")
+    cache: Dict[str, Any] = {}
 
     def preproc(ds):
         processed = ds.load().chunk(-1)

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -226,7 +226,8 @@ def test_batch_exceptions(sample_ds_1d):
         assert len(e) == 1
 
 
-def test_batcher_cached_getitem(sample_ds_1d) -> None:
+@pytest.mark.parametrize("preload", [True, False])
+def test_batcher_cached_getitem(sample_ds_1d, preload) -> None:
     pytest.importorskip("zarr")
     cache: Dict[str, Any] = {}
 
@@ -236,7 +237,11 @@ def test_batcher_cached_getitem(sample_ds_1d) -> None:
         return processed
 
     bg = BatchGenerator(
-        sample_ds_1d, input_dims={"x": 10}, cache=cache, cache_preprocess=preproc
+        sample_ds_1d,
+        input_dims={"x": 10},
+        cache=cache,
+        cache_preprocess=preproc,
+        preload_batch=preload,
     )
 
     # first batch
@@ -257,5 +262,17 @@ def test_batcher_cached_getitem(sample_ds_1d) -> None:
     assert ds_no_cache.attrs["foo"] == "bar"
     assert ds_cache.attrs["foo"] == "bar"
 
+    xr.testing.assert_equal(ds_no_cache, ds_cache)
+    xr.testing.assert_identical(ds_no_cache, ds_cache)
+
+    # without preprocess func
+    bg = BatchGenerator(
+        sample_ds_1d, input_dims={"x": 10}, cache=cache, preload_batch=preload
+    )
+    assert bg.cache_preprocess is None
+    assert bg[0].dims["x"] == 10
+    ds_no_cache = bg[1]
+    assert "1/.zgroup" in cache
+    ds_cache = bg[1]
     xr.testing.assert_equal(ds_no_cache, ds_cache)
     xr.testing.assert_identical(ds_no_cache, ds_cache)


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a new cache feature to Xbatcher's `BatchGenerator`. As implemented, this requires Zarr to serialize Xarray datasets. The cache itself is entirely pluggable, accepting any dict-like object to store caches in. 

I'm putting this up to help foster discussions in #109. I'm still not sure its the best path forward but I'd like to get some feedback and this felt like a tangible way to test this idea out. 

If you want to try this out, you could try this:

```python
In [1]: import xarray as xr

In [2]: import xbatcher

In [3]: import zarr

In [4]: cache = zarr.storage.DirectoryStore('/flash/fast/storage/cache')

In [5]: ds = xr.tutorial.open_dataset('air_temperature')

In [6]: gen = xbatcher.BatchGenerator(ds, input_dims={'lat': 10, 'lon': 10}, cache=cache)

In [7]: %%time
   ...: for b in gen:
   ...:     pass
   ...: 
CPU times: user 95 ms, sys: 40.8 ms, total: 136 ms
Wall time: 146 ms

In [8]: %%time
   ...: for b in gen:
   ...:     pass
   ...: 
CPU times: user 59.6 ms, sys: 11.4 ms, total: 70.9 ms
Wall time: 65.5 ms
```

_Note that I used a directory store here but this could be any zarr-friendly store (e.g. s3, redis, etc.)_