### PR TITLE
Use informative error message for optional dependency imports

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,7 +12,7 @@ Installation
 
 Xbatcher can be installed from PyPI as::
 
-    pip install xbatcher
+    python -m pip install xbatcher
 
 Or via Conda as::
 
@@ -20,7 +20,33 @@ Or via Conda as::
 
 Or from source as::
 
-    pip install git+https://github.com/xarray-contrib/xbatcher.git
+    python -m pip install git+https://github.com/xarray-contrib/xbatcher.git
+
+Optional Dependencies
+~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+    The required dependencies installed with Xbatcher are `Xarray <https://xarray.dev/>`_,
+    `Dask <https://www.dask.org/>`_, and `NumPy <https://numpy.org/>`_.
+    You will need to separately install `TensorFlow <https://www.tensorflow.org/>`_
+    or `PyTorch <https://pytorch.org/>`_ to use those data loaders or
+    Xarray accessors.
+
+To install Xbatcher and PyTorch via `Conda <https://docs.conda.io/>`_::
+
+    conda install -c conda-forge xbatcher pytorch
+
+Or via PyPI::
+
+    python -m pip install xbatcher[torch]
+
+To install Xbatcher and TensorFlow via `Conda <https://docs.conda.io/>`_::
+
+    conda install -c conda-forge xbatcher tensorflow
+
+Or via PyPI::
+
+    python -m pip install xbatcher[tensorflow]
 
 Basic Usage
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ fallback_version = "999"
 
 [tool.isort]
 profile = 'black'
-known_third_party = ["numpy", "pytest", "setuptools", "sphinx_autosummary_accessors", "tensorflow", "torch", "xarray"]
+known_third_party = ["numpy", "pytest", "setuptools", "sphinx_autosummary_accessors", "torch", "xarray"]
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/xbatcher/loaders/keras.py
+++ b/xbatcher/loaders/keras.py
@@ -1,6 +1,12 @@
 from typing import Any, Callable, Optional, Tuple
 
-import tensorflow as tf
+try:
+    import tensorflow as tf
+except ImportError:
+    raise ImportError(
+        "The Xbatcher TensorFlow Dataset API depends on TensorFlow. Please "
+        "install TensorFlow to proceed."
+    )
 
 # Notes:
 # This module includes one Keras dataset, which can be provided to model.fit().

--- a/xbatcher/loaders/keras.py
+++ b/xbatcher/loaders/keras.py
@@ -2,11 +2,11 @@ from typing import Any, Callable, Optional, Tuple
 
 try:
     import tensorflow as tf
-except ImportError:
+except ImportError as exc:
     raise ImportError(
         "The Xbatcher TensorFlow Dataset API depends on TensorFlow. Please "
         "install TensorFlow to proceed."
-    )
+    ) from exc
 
 # Notes:
 # This module includes one Keras dataset, which can be provided to model.fit().

--- a/xbatcher/loaders/torch.py
+++ b/xbatcher/loaders/torch.py
@@ -1,6 +1,12 @@
 from typing import Any, Callable, Optional, Tuple
 
-import torch
+try:
+    import torch
+except ImportError:
+    raise ImportError(
+        "The Xbatcher PyTorch Dataset API depends on PyTorch. Please "
+        "install PyTorch to proceed."
+    )
 
 # Notes:
 # This module includes two PyTorch datasets.

--- a/xbatcher/loaders/torch.py
+++ b/xbatcher/loaders/torch.py
@@ -2,11 +2,11 @@ from typing import Any, Callable, Optional, Tuple
 
 try:
     import torch
-except ImportError:
+except ImportError as exc:
     raise ImportError(
         "The Xbatcher PyTorch Dataset API depends on PyTorch. Please "
         "install PyTorch to proceed."
-    )
+    ) from exc
 
 # Notes:
 # This module includes two PyTorch datasets.


### PR DESCRIPTION
**Description of proposed changes**

This PR adds information about optional dependencies to the installation instructions and improves the ImportError message when trying to use the data loaders without having PyTorch and/or TensorFlow installed.

Open to opinions about whether these error messages should also be used for the torch and tf xarray accessors and if it's necessary to add tests for this case. This drops code coverage to 99%.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

Fixes #
