### PR TITLE
New BatchSchema class to generate patch selectors and combine into batch selectors

### DIFF
--- a/xbatcher/__init__.py
+++ b/xbatcher/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import version as _version
 
 from . import testing  # noqa: F401
 from .accessors import BatchAccessor  # noqa: F401
-from .generators import BatchGenerator  # noqa: F401
+from .generators import BatchGenerator, BatchSchema  # noqa: F401
 from .util.print_versions import show_versions  # noqa: F401
 
 try:

--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Union
 
 import xarray as xr
 
@@ -19,13 +19,13 @@ def _as_xarray_dataarray(xr_obj: Union[xr.Dataset, xr.DataArray]) -> xr.DataArra
 @xr.register_dataarray_accessor("batch")
 @xr.register_dataset_accessor("batch")
 class BatchAccessor:
-    def __init__(self, xarray_obj):
+    def __init__(self, xarray_obj: Union[xr.Dataset, xr.DataArray]):
         """
         Batch accessor returning a BatchGenerator object via the `generator method`
         """
         self._obj = xarray_obj
 
-    def generator(self, *args, **kwargs):
+    def generator(self, *args, **kwargs) -> BatchGenerator:
         """
         Return a BatchGenerator via the batch accessor
 
@@ -42,10 +42,10 @@ class BatchAccessor:
 @xr.register_dataarray_accessor("tf")
 @xr.register_dataset_accessor("tf")
 class TFAccessor:
-    def __init__(self, xarray_obj):
+    def __init__(self, xarray_obj: Union[xr.Dataset, xr.DataArray]):
         self._obj = xarray_obj
 
-    def to_tensor(self):
+    def to_tensor(self) -> Any:
         """Convert this DataArray to a tensorflow.Tensor"""
         import tensorflow as tf
 
@@ -57,10 +57,10 @@ class TFAccessor:
 @xr.register_dataarray_accessor("torch")
 @xr.register_dataset_accessor("torch")
 class TorchAccessor:
-    def __init__(self, xarray_obj):
+    def __init__(self, xarray_obj: Union[xr.Dataset, xr.DataArray]):
         self._obj = xarray_obj
 
-    def to_tensor(self):
+    def to_tensor(self) -> Any:
         """Convert this DataArray to a torch.Tensor"""
         import torch
 
@@ -68,7 +68,7 @@ class TorchAccessor:
 
         return torch.tensor(data=dataarray.data)
 
-    def to_named_tensor(self):
+    def to_named_tensor(self) -> Any:
         """
         Convert this DataArray to a torch.Tensor with named dimensions.
 

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -1,17 +1,142 @@
 """Classes for iterating through xarray datarrays / datasets in batches."""
 
 import itertools
-from typing import Any, Dict, Hashable, Iterator, List, Sequence, Tuple, Union
+from dataclasses import dataclass
+from operator import itemgetter
+from typing import Dict, Hashable, Iterator, List, Sequence, Union
 
 import xarray as xr
 
-DimSelector = Dict[Hashable, slice]
-ConcatBatchSelector = Tuple[DimSelector, List[DimSelector]]
-BatchSelector = Union[
-    List[ConcatBatchSelector],
-    Iterator[DimSelector],
-]
-BatchSelectors = Union[Dict[int, ConcatBatchSelector], Dict[int, DimSelector]]
+BatchSelector = List[Dict[Hashable, slice]]
+BatchSelectorSet = Dict[int, BatchSelector]
+
+
+@dataclass
+class BatchSchema:
+    """
+    A representation of the indices and stacking/transposing parameters needed
+    to generator batches from Xarray Datasets and DataArrays using
+    xbatcher.BatchGenerator.
+
+    Parameters
+    ----------
+    ds : ``xarray.Dataset`` or ``xarray.DataArray``
+        The data to iterate over. Unlike for the BatchGenerator, the data is
+        not retained as a class attribute for the BatchSchema.
+    input_dims : dict
+        A dictionary specifying the size of the inputs in each dimension,
+        e.g. ``{'lat': 30, 'lon': 30}``
+        These are the dimensions the ML library will see. All other dimensions
+        will be stacked into one dimension called ``sample``.
+    input_overlap : dict, optional
+        A dictionary specifying the overlap along each dimension
+        e.g. ``{'lat': 3, 'lon': 3}``
+    batch_dims : dict, optional
+        A dictionary specifying the size of the batch along each dimension
+        e.g. ``{'time': 10}``. These will always be iterated over.
+    concat_input_dims : bool, optional
+        If ``True``, the dimension chunks specified in ``input_dims`` will be
+        concatenated and stacked into the ``sample`` dimension. The batch index
+        will be included as a new level ``input_batch`` in the ``sample``
+        coordinate.
+        If ``False``, the dimension chunks specified in ``input_dims`` will be
+        iterated over.
+    preload_batch : bool, optional
+        If ``True``, each batch will be loaded into memory before reshaping /
+        processing, triggering any dask arrays to be computed.
+
+    Notes
+    -----
+    The BatchSchema is experimental and subject to change without notice.
+    """
+
+    def __init__(
+        self,
+        ds: Union[xr.Dataset, xr.DataArray],
+        input_dims: Dict[Hashable, int],
+        input_overlap: Dict[Hashable, int] = {},
+        batch_dims: Dict[Hashable, int] = {},
+        concat_input_bins: bool = True,
+        preload_batch: bool = True,
+    ):
+        self.input_dims = dict(input_dims)
+        self.input_overlap = input_overlap
+        self.batch_dims = dict(batch_dims)
+        self.concat_input_dims = concat_input_bins
+        self.preload_batch = preload_batch
+        self.selectors: BatchSelectorSet = self._gen_batch_selectors(ds)
+
+    def _gen_batch_selectors(self, ds) -> BatchSelectorSet:
+        """
+        Create batch selectors dict, which can be used to create a batch
+        from an xarray data object.
+        """
+        # Separate batch_dims that are/are not also included in input_dims
+        self._duplicate_batch_dims = {
+            dim: length
+            for dim, length in self.batch_dims.items()
+            if self.input_dims.get(dim) is not None
+        }
+        self._unique_batch_dims = {
+            dim: length
+            for dim, length in self.batch_dims.items()
+            if self.input_dims.get(dim) is None
+        }
+        # Create an iterator that returns an object usable for .isel in xarray
+        patch_selectors = self._gen_patch_selectors(ds)
+        # Create the Dict containing batch selectors
+        if self.concat_input_dims:  # Combine the patches into batches
+            batch_selectors = self._combine_patches_into_batch(ds, patch_selectors)
+            return dict(enumerate(batch_selectors))
+        else:  # Each patch gets its own batch
+            return {ind: [value] for ind, value in enumerate(patch_selectors)}
+
+    def _gen_patch_selectors(self, ds) -> Iterator[Dict[Hashable, slice]]:
+        """
+        Create an iterator that can be used to index an Xarray Dataset/DataArray.
+        """
+        if self._duplicate_batch_dims and not self.concat_input_dims:
+            raise UserWarning(
+                f"""
+                The following dimensions were included in both ``input_dims``
+                and ``batch_dims``. Since ``concat_input_dims`` is ``False``,
+                these dimensions will not impact batch generation: {self._duplicate_batch_dims}
+                """
+            )
+        # Generate the slices by iterating over batch_dims and input_dims
+        all_slices = _iterate_through_dimensions(
+            ds,
+            dims=dict(**self._unique_batch_dims, **self.input_dims),
+            overlap=self.input_overlap,
+        )
+        return all_slices
+
+    def _combine_patches_into_batch(
+        self, ds, patch_selectors
+    ) -> List[List[Dict[Hashable, slice]]]:
+        """
+        Combine the patch selectors to form a batch
+        """
+        # Check that patches are only combined with concat_input_dims
+        if not self.concat_input_dims:
+            raise AssertionError(
+                "Patches should only be combined into batches when ``concat_input_dims`` is ``True``"
+            )
+        # If ``batch_dims`` isn't used, all patches will be included in a single batch
+        if not self.batch_dims:
+            batch_selectors = [list(patch_selectors)]
+        elif self._duplicate_batch_dims:
+            raise NotImplementedError("Not Implemented")
+        # Group patches based on the unique slices for dimensions in ``batch_dims``
+        else:
+            batch_selectors = [
+                list(value)
+                for _, value in itertools.groupby(
+                    patch_selectors, key=itemgetter(*self.batch_dims)
+                )
+            ]
+        # Group patches based on the unique dimensions in ``batch_dims``
+        return batch_selectors
 
 
 def _gen_slices(*, dim_size: int, slice_size: int, overlap: int = 0) -> List[slice]:
@@ -134,21 +259,41 @@ class BatchGenerator:
     ):
 
         self.ds = ds
-        self.input_dims = dict(input_dims)
-        self.input_overlap = input_overlap
-        self.batch_dims = dict(batch_dims)
-        self.concat_input_dims = concat_input_dims
-        self.preload_batch = preload_batch
-        self._batch_selectors: Dict[
-            int, Any
-        ] = self._gen_batch_selectors()  # dict cache for batches
+        self._batch_selectors: BatchSchema = BatchSchema(
+            ds,
+            input_dims=input_dims,
+            input_overlap=input_overlap,
+            batch_dims=batch_dims,
+            concat_input_bins=concat_input_dims,
+            preload_batch=preload_batch,
+        )
+
+    @property
+    def input_dims(self):
+        return self._batch_selectors.input_dims
+
+    @property
+    def input_overlap(self):
+        return self._batch_selectors.input_overlap
+
+    @property
+    def batch_dims(self):
+        return self._batch_selectors.batch_dims
+
+    @property
+    def concat_input_dims(self):
+        return self._batch_selectors.concat_input_dims
+
+    @property
+    def preload_batch(self):
+        return self._batch_selectors.preload_batch
 
     def __iter__(self) -> Iterator[Union[xr.DataArray, xr.Dataset]]:
-        for idx in self._batch_selectors:
+        for idx in self._batch_selectors.selectors:
             yield self[idx]
 
     def __len__(self) -> int:
-        return len(self._batch_selectors)
+        return len(self._batch_selectors.selectors)
 
     def __getitem__(self, idx: int) -> Union[xr.Dataset, xr.DataArray]:
 
@@ -158,21 +303,20 @@ class BatchGenerator:
             )
 
         if idx < 0:
-            idx = list(self._batch_selectors)[idx]
+            idx = list(self._batch_selectors.selectors)[idx]
 
-        if idx in self._batch_selectors:
+        if idx in self._batch_selectors.selectors:
 
             if self.concat_input_dims:
                 new_dim_suffix = "_input"
                 all_dsets: List = []
-                batch_dims_selector, input_dims_selectors = self._batch_selectors[idx]
-                batch_ds = self.ds.isel(batch_dims_selector)
-                if self.preload_batch:
-                    batch_ds.load()
-                for selector in input_dims_selectors:
+                for selector in self._batch_selectors.selectors[idx]:
+                    batch_ds = self.ds.isel(selector)
+                    if self.preload_batch:
+                        batch_ds.load()
                     all_dsets.append(
                         _drop_input_dims(
-                            batch_ds.isel(dict(**selector)),
+                            batch_ds,
                             self.input_dims,
                             suffix=new_dim_suffix,
                         )
@@ -181,7 +325,7 @@ class BatchGenerator:
                 new_input_dims = [str(dim) + new_dim_suffix for dim in self.input_dims]
                 return _maybe_stack_batch_dims(dsc, new_input_dims)
             else:
-                batch_ds = self.ds.isel(self._batch_selectors[idx])
+                batch_ds = self.ds.isel(self._batch_selectors.selectors[idx][0])
                 if self.preload_batch:
                     batch_ds.load()
                 return _maybe_stack_batch_dims(
@@ -190,31 +334,3 @@ class BatchGenerator:
                 )
         else:
             raise IndexError("list index out of range")
-
-    def _gen_batch_selectors(
-        self,
-    ) -> BatchSelectors:
-        """
-        Create batch selectors dict, which can be used to create a batch
-        from an xarray data object.
-        """
-        if self.concat_input_dims:
-            batch_dim_selectors = _iterate_through_dimensions(
-                self.ds, dims=self.batch_dims
-            )
-            # TODO: Consider iterator protocol rather than copying to list
-            input_dim_selectors = list(
-                _iterate_through_dimensions(
-                    self.ds, dims=self.input_dims, overlap=self.input_overlap
-                )
-            )
-            batch_selectors: BatchSelector = [
-                (selector, input_dim_selectors) for selector in batch_dim_selectors
-            ]
-        else:
-            batch_selectors = _iterate_through_dimensions(
-                self.ds,
-                dims=dict(**self.batch_dims, **self.input_dims),
-                overlap=self.input_overlap,
-            )
-        return dict(enumerate(batch_selectors))

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Hashable, Iterator, List, Sequence, Union
 import xarray as xr
 
 
-def _gen_slices(*, dim_size: int, slice_size: int, overlap: int = 0) -> Any:
+def _gen_slices(*, dim_size: int, slice_size: int, overlap: int = 0) -> List[slice]:
     # return a list of slices to chop up a single dimension
     if overlap >= slice_size:
         raise ValueError(

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -55,11 +55,15 @@ class BatchSchema:
         self,
         ds: Union[xr.Dataset, xr.DataArray],
         input_dims: Dict[Hashable, int],
-        input_overlap: Dict[Hashable, int] = {},
-        batch_dims: Dict[Hashable, int] = {},
+        input_overlap: Dict[Hashable, int] = None,
+        batch_dims: Dict[Hashable, int] = None,
         concat_input_bins: bool = True,
         preload_batch: bool = True,
     ):
+        if input_overlap is None:
+            input_overlap = {}
+        if batch_dims is None:
+            batch_dims = {}
         self.input_dims = dict(input_dims)
         self.input_overlap = input_overlap
         self.batch_dims = dict(batch_dims)

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -135,7 +135,6 @@ class BatchSchema:
                     patch_selectors, key=itemgetter(*self.batch_dims)
                 )
             ]
-        # Group patches based on the unique dimensions in ``batch_dims``
         return batch_selectors
 
 

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -170,10 +170,6 @@ class BatchSchema:
         each patch. Required when a dimension is duplicated between ``batch_dims``
         and ``input_dims``.
         """
-        if self._unique_batch_dims:
-            raise NotImplementedError(
-                "Currently either all or no batch_dims must be duplicated as input_dims."
-            )
         self._gen_patch_numbers(ds)
         self._gen_batch_numbers(ds)
         batch_id_per_patch = self._get_batch_multi_index_per_patch()

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -42,7 +42,7 @@ def _iterate_through_dataset(
         dim_slices.append(_slices(dimsize, size, olap))
 
     for slices in itertools.product(*dim_slices):
-        selector = {key: slice for key, slice in zip(dims, slices)}
+        selector = dict(zip(dims, slices))
         yield selector
 
 
@@ -188,7 +188,7 @@ class BatchGenerator:
             else:
                 batches += list(input_generator)
 
-        return dict(zip(range(len(batches)), batches))
+        return dict(enumerate(batches))
 
     def _iterate_batch_dims(self) -> Any:
         return _iterate_through_dataset(self.ds, self.batch_dims)

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -197,12 +197,15 @@ class BatchSchema:
         in each batch per dimension.
         """
         self._n_patches_per_batch: Dict[Hashable, int] = {
-            dim: int(np.ceil(length / self._input_stride[dim]))
+            dim: int(np.ceil(length / self._input_stride.get(dim, length)))
             for dim, length in self.batch_dims.items()
         }
         self._n_patches_per_dim: Dict[Hashable, int] = {
-            dim: int((ds.sizes[dim] - self.input_overlap.get(dim, 0)) // length)
-            for dim, length in self._input_stride.items()
+            dim: int(
+                (ds.sizes[dim] - self.input_overlap.get(dim, 0))
+                // (length - self.input_overlap.get(dim, 0))
+            )
+            for dim, length in self._all_sliced_dims.items()
         }
 
     def _gen_batch_numbers(self, ds: Union[xr.DataArray, xr.Dataset]):

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -430,13 +430,21 @@ class BatchGenerator:
             if self.concat_input_dims:
                 new_dim_suffix = "_input"
                 all_dsets: List = []
+                batch_selector = {}
+                for dim in self._batch_selectors.batch_dims.keys():
+                    starts = [
+                        x[dim].start for x in self._batch_selectors.selectors[idx]
+                    ]
+                    stops = [x[dim].stop for x in self._batch_selectors.selectors[idx]]
+                    batch_selector[dim] = slice(min(starts), max(stops))
+                batch_ds = self.ds.isel(batch_selector)
+                if self.preload_batch:
+                    batch_ds.load()
                 for selector in self._batch_selectors.selectors[idx]:
-                    batch_ds = self.ds.isel(selector)
-                    if self.preload_batch:
-                        batch_ds.load()
+                    patch_ds = self.ds.isel(selector)
                     all_dsets.append(
                         _drop_input_dims(
-                            batch_ds,
+                            patch_ds,
                             self.input_dims,
                             suffix=new_dim_suffix,
                         )

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -166,10 +166,13 @@ class BatchGenerator:
                 new_dim_suffix = "_input"
                 all_dsets: List = []
                 batch_dims_selector, input_dims_selectors = self._batch_selectors[idx]
+                batch_ds = self.ds.isel(batch_dims_selector)
+                if self.preload_batch:
+                    batch_ds.load()
                 for selector in input_dims_selectors:
                     all_dsets.append(
                         _drop_input_dims(
-                            self.ds.isel(dict(**batch_dims_selector, **selector)),
+                            batch_ds.isel(dict(**selector)),
                             self.input_dims,
                             suffix=new_dim_suffix,
                         )
@@ -178,8 +181,11 @@ class BatchGenerator:
                 new_input_dims = [str(dim) + new_dim_suffix for dim in self.input_dims]
                 return _maybe_stack_batch_dims(dsc, new_input_dims)
             else:
+                batch_ds = self.ds.isel(self._batch_selectors[idx])
+                if self.preload_batch:
+                    batch_ds.load()
                 return _maybe_stack_batch_dims(
-                    self.ds.isel(self._batch_selectors[idx]),
+                    batch_ds,
                     list(self.input_dims),
                 )
         else:

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -22,7 +22,7 @@ def _gen_slices(*, dim_size: int, slice_size: int, overlap: int = 0) -> List[sli
     return slices
 
 
-def _iterate_through_dataset(
+def _iterate_over_dimensions(
     ds: Union[xr.Dataset, xr.DataArray],
     *,
     dims: Dict[Hashable, int],
@@ -193,9 +193,9 @@ class BatchGenerator:
         return dict(enumerate(batches))
 
     def _iterate_batch_dims(self) -> Any:
-        return _iterate_through_dataset(self.ds, dims=self.batch_dims)
+        return _iterate_over_dimensions(self.ds, dims=self.batch_dims)
 
     def _iterate_input_dims(self) -> Any:
-        return _iterate_through_dataset(
+        return _iterate_over_dimensions(
             self.ds, dims=self.input_dims, overlap=self.input_overlap
         )

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -1,7 +1,7 @@
 """Classes for iterating through xarray datarrays / datasets in batches."""
 
 import itertools
-from typing import Any, Dict, Hashable, Iterator, List, OrderedDict, Sequence, Union
+from typing import Any, Dict, Hashable, Iterator, List, Sequence, Union
 
 import xarray as xr
 
@@ -25,7 +25,7 @@ def _gen_slices(*, dim_size: int, slice_size: int, overlap: int = 0) -> Any:
 def _iterate_through_dataset(
     ds: Union[xr.Dataset, xr.DataArray],
     *,
-    dims: OrderedDict[Hashable, int],
+    dims: Dict[Hashable, int],
     overlap: Dict[Hashable, int] = {},
 ) -> Any:
     dim_slices = []
@@ -51,7 +51,7 @@ def _iterate_through_dataset(
 
 def _drop_input_dims(
     ds: Union[xr.Dataset, xr.DataArray],
-    input_dims: OrderedDict[Hashable, int],
+    input_dims: Dict[Hashable, int],
     suffix: str = "_input",
 ) -> Union[xr.Dataset, xr.DataArray]:
     # remove input_dims coordinates from datasets, rename the dimensions
@@ -127,10 +127,9 @@ class BatchGenerator:
     ):
 
         self.ds = ds
-        # should be a dict
-        self.input_dims = OrderedDict(input_dims)
+        self.input_dims = dict(input_dims)
         self.input_overlap = input_overlap
-        self.batch_dims = OrderedDict(batch_dims)
+        self.batch_dims = dict(batch_dims)
         self.concat_input_dims = concat_input_dims
         self.preload_batch = preload_batch
         self._batches: Dict[int, Any] = self._gen_batches()  # dict cache for batches

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -32,7 +32,7 @@ def _iterate_over_dimensions(
     for dim in dims:
         dim_size = ds.sizes[dim]
         slice_size = dims[dim]
-        olap = overlap.get(dim, 0)
+        slice_overlap = overlap.get(dim, 0)
         if slice_size > dim_size:
             raise ValueError(
                 "input sample length must be less than or equal to the "
@@ -41,7 +41,7 @@ def _iterate_over_dimensions(
                 f"for {dim}"
             )
         dim_slices.append(
-            _gen_slices(dim_size=dim_size, slice_size=slice_size, overlap=olap)
+            _gen_slices(dim_size=dim_size, slice_size=slice_size, overlap=slice_overlap)
         )
 
     for slices in itertools.product(*dim_slices):

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Hashable, Iterator, List, OrderedDict, Sequence, U
 import xarray as xr
 
 
-def _slices(dimsize: int, size: int, overlap: int = 0) -> Any:
+def _gen_slices(dimsize: int, size: int, overlap: int = 0) -> Any:
     # return a list of slices to chop up a single dimension
     if overlap >= size:
         raise ValueError(
@@ -39,7 +39,7 @@ def _iterate_through_dataset(
                 f"is greater than the dimension length of {dimsize} "
                 f"for {dim}"
             )
-        dim_slices.append(_slices(dimsize, size, olap))
+        dim_slices.append(_gen_slices(dimsize, size, olap))
 
     for slices in itertools.product(*dim_slices):
         selector = dict(zip(dims, slices))

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -27,7 +27,7 @@ def _iterate_over_dimensions(
     *,
     dims: Dict[Hashable, int],
     overlap: Dict[Hashable, int] = {},
-) -> Any:
+) -> Iterator[Dict[Hashable, slice]]:
     dim_slices = []
     for dim in dims:
         dim_size = ds.sizes[dim]
@@ -43,7 +43,6 @@ def _iterate_over_dimensions(
         dim_slices.append(
             _gen_slices(dim_size=dim_size, slice_size=slice_size, overlap=slice_overlap)
         )
-
     for slices in itertools.product(*dim_slices):
         selector = dict(zip(dims, slices))
         yield selector

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -1,6 +1,7 @@
 """Classes for iterating through xarray datarrays / datasets in batches."""
 
 import itertools
+import warnings
 from operator import itemgetter
 from typing import Any, Dict, Hashable, Iterator, List, Sequence, Union
 
@@ -106,12 +107,10 @@ class BatchSchema:
         Create an iterator that can be used to index an Xarray Dataset/DataArray.
         """
         if self._duplicate_batch_dims and not self.concat_input_dims:
-            raise UserWarning(
-                f"""
-                The following dimensions were included in both ``input_dims``
-                and ``batch_dims``. Since ``concat_input_dims`` is ``False``,
-                these dimensions will not impact batch generation: {self._duplicate_batch_dims}
-                """
+            warnings.warn(
+                "The following dimensions were included in both ``input_dims`` "
+                "and ``batch_dims``. Since ``concat_input_dims`` is ``False``, "
+                f"these dimensions will not impact batch generation: {self._duplicate_batch_dims}"
             )
         # Generate the slices by iterating over batch_dims and input_dims
         all_slices = _iterate_through_dimensions(

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -1,7 +1,6 @@
 """Classes for iterating through xarray datarrays / datasets in batches."""
 
 import itertools
-from dataclasses import dataclass
 from operator import itemgetter
 from typing import Any, Dict, Hashable, Iterator, List, Sequence, Union
 
@@ -13,7 +12,6 @@ BatchSelector = List[Dict[Hashable, slice]]
 BatchSelectorSet = Dict[int, BatchSelector]
 
 
-@dataclass
 class BatchSchema:
     """
     A representation of the indices and stacking/transposing parameters needed
@@ -66,16 +64,7 @@ class BatchSchema:
         self.batch_dims = dict(batch_dims)
         self.concat_input_dims = concat_input_bins
         self.preload_batch = preload_batch
-        self.selectors: BatchSelectorSet = self._gen_batch_selectors(ds)
-
-    def _gen_batch_selectors(
-        self, ds: Union[xr.DataArray, xr.Dataset]
-    ) -> BatchSelectorSet:
-        """
-        Create batch selectors dict, which can be used to create a batch
-        from an xarray data object.
-        """
-        # Separate batch_dims that are/are not also included in input_dims
+        # Store helpful information based on arguments
         self._duplicate_batch_dims: Dict[Hashable, int] = {
             dim: length
             for dim, length in self.batch_dims.items()
@@ -93,6 +82,15 @@ class BatchSchema:
         self._all_sliced_dims: Dict[Hashable, int] = dict(
             **self._unique_batch_dims, **self.input_dims
         )
+        self.selectors: BatchSelectorSet = self._gen_batch_selectors(ds)
+
+    def _gen_batch_selectors(
+        self, ds: Union[xr.DataArray, xr.Dataset]
+    ) -> BatchSelectorSet:
+        """
+        Create batch selectors dict, which can be used to create a batch
+        from an xarray data object.
+        """
         # Create an iterator that returns an object usable for .isel in xarray
         patch_selectors = self._gen_patch_selectors(ds)
         # Create the Dict containing batch selectors

--- a/xbatcher/testing.py
+++ b/xbatcher/testing.py
@@ -101,9 +101,10 @@ def _get_sample_length(
     """
     if generator.concat_input_dims:
         batch_concat_dims = [
-            generator.ds.sizes.get(k)
-            // np.nanmax([v, generator.batch_dims.get(k, np.nan)])
-            for k, v in generator.input_dims.items()
+            generator.batch_dims.get(dim) // length
+            if generator.batch_dims.get(dim)
+            else generator.ds.sizes.get(dim) // length
+            for dim, length in generator.input_dims.items()
         ]
     else:
         batch_concat_dims = []

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -115,9 +115,6 @@ def test_batch_1d_concat(sample_ds_1d, input_size):
         assert "x" in ds_batch.coords
 
 
-@pytest.mark.xfail(
-    reason="Bug described in https://github.com/xarray-contrib/xbatcher/issues/131"
-)
 def test_batch_1d_concat_duplicate_dim(sample_ds_1d):
     """
     Test batch generation for a 1D dataset using ``concat_input_dims`` when
@@ -219,9 +216,6 @@ def test_batch_3d_1d_input(sample_ds_3d, input_size):
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
 
 
-@pytest.mark.xfail(
-    reason="Bug described in https://github.com/xarray-contrib/xbatcher/issues/131"
-)
 @pytest.mark.parametrize("concat", [True, False])
 def test_batch_3d_1d_input_batch_dims(sample_ds_3d, concat):
     """
@@ -239,9 +233,6 @@ def test_batch_3d_1d_input_batch_dims(sample_ds_3d, concat):
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
 
 
-@pytest.mark.xfail(
-    reason="Bug described in https://github.com/xarray-contrib/xbatcher/issues/131"
-)
 def test_batch_3d_1d_input_batch_concat_duplicate_dim(sample_ds_3d):
     """
     Test batch generation for a 3D dataset using ``concat_input_dims`` when

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -216,7 +216,18 @@ def test_batch_3d_1d_input(sample_ds_3d, input_size):
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
 
 
-@pytest.mark.parametrize("concat", [True, False])
+@pytest.mark.parametrize(
+    "concat",
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                reason="Bug described in https://github.com/xarray-contrib/xbatcher/issues/126"
+            ),
+        ),
+    ],
+)
 def test_batch_3d_1d_input_batch_dims(sample_ds_3d, concat):
     """
     Test batch generation for a 3D dataset using ``input_dims`` and batch_dims``.


### PR DESCRIPTION
**Description of proposed changes**

This PR is a major overhaul of xbatcher’s internals. Users should not notice any external changes, apart from bug fixes and some performance differences.

## New BatchSchema class

In v0.2.0, information about the batch_selectors was stored as a dict in the `._batch_selectors` attribute of the `BatchGenerator` class. This PR introduces `BatchSchema` which contains all necessary information about the batch selectors. `BatchGenerator` now creates an instance of  `BatchSchema`, which handles the creation of `selectors` object. The purpose of `BatchGenerator` is to create batches (xarray Datasets/DataArrays) from those selector objects. This opens up possibilities including serializing/deserializing the BatchSchema (e.g., `BatchSchema.to_json()` and `BatchSchema.from_json()`), caching `BatchSchema` objects separate from caching batches, and relatedly applying one `BatchSchema` instance to multiple xarray datasets.

The representation of the batch selectors (`BatchSchema.selectors`) is the same regardless of whether `concat_input_dims`is `True` or `False`(in contrast to v0.2.0 where the type varied based on that parameter). The selectors object is still a dict with keys representing the batch index and values representing the batch selector. The batch selector is a list of dicts, where the keys are the dimensions included in `batch_dims` and/or `input_dims` and the values are slices used to index the xarray dataset/dataarray. It’s simplest to refer to the subset of data created by each of these dictionaries as a patch. If `concat_input_dims` is False, each list has length 1 (i.e., 1 patch per batch). If `concat_input_dims` is True, the lists can contain multiple patches, which will be concatenated to form a batch by the generator.

## Bug fixes
**Handling batch_dims** (#131, #121)

As explained [https://github.com/xarray-contrib/xbatcher/issues/121#issuecomment-1301331750](https://github.com/xarray-contrib/xbatcher/issues/121#issuecomment-1301331750), this issue stemmed from information about the `batch_dims` indices not being stored in the selectors object. After this PR, each patch contains information about all dims that are indexed on (i.e., any dim included in `input_dims` or `batch_dims`). Those patches are then combined into batches based on the number of items in the list for each batch selector.

**Handling of overlapping samples**

In v.2.0, the `batch_dims`  were sliced first and subsequently `index_dims` were sliced. This had the consequence of missing away any patch that overlapped two batches. Now, the smallest patches created by the combination of `batch_dims` and `input_dims` are defined first and these are then combined into batches based on the starting index (see simple example below).

![image](https://user-images.githubusercontent.com/14077947/208769331-3235a5db-6ffb-4964-80fa-88153c0ea1d7.png)


## Performance changes

Running the benchmarks from https://github.com/xarray-contrib/xbatcher/pull/140 on main, `4d8e2c84a2d405e237f60f1df5286dd766e06ff0`, and this PR revealed a mix of performance increases and decreases. Based on a quick investigation, I think that the regressions mostly relate to loading each batch individually, whereas before this PR if a dimension was included in `batch_dims` and `input_dims`, the data associated with the slice from `batch_dims` would be loaded even if `concat_input_dims` was False and that slice shouldn’t matter. Since loading more data improves performance, those benchmarks are now slower. Also, the handling of overlapping samples means there are more patches which will impact performance. In contrast, the benchmarks affected by #121 are now much faster.

```bash
$ asv continuous main batch-dims-bug
before           after         ratio
     [c0dd0029]       [9d0fcb05]
     <main>           <batch-dims-bug>
+     2.59±0.05ms       21.9±0.2ms     8.47  benchmarks.Generator.time_batch_preload(True)
+      82.9±0.4μs        112±0.5μs     1.35  benchmarks.TorchLoader.time_iterable_dataset
+      85.8±0.4μs        114±0.4μs     1.33  benchmarks.TorchLoader.time_map_dataset
+     16.6±0.05ms       19.3±0.2ms     1.16  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {}, {'x': 2})
+     10.4±0.08ms      12.0±0.07ms     1.16  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {}, {})
+        5.77±0ms      6.65±0.04ms     1.15  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {}, {'x': 1})
+      63.9±0.7ms      73.4±0.08ms     1.15  benchmarks.Accessor.time_accessor_input_dim({'x': 2, 'y': 2})
+      32.1±0.1ms      36.9±0.07ms     1.15  benchmarks.Accessor.time_accessor_input_dim({'x': 4, 'y': 2})
+     6.36±0.05ms      7.29±0.07ms     1.15  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {}, {'x': 2})
+     5.25±0.01ms      6.01±0.01ms     1.14  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {}, {})
+     10.4±0.07ms      11.9±0.07ms     1.14  benchmarks.Generator.time_batch_concat({'x': 5, 'y': 5}, False)
+     12.6±0.06ms       14.3±0.1ms     1.14  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {}, {'x': 1})
-     18.8±0.08ms      7.32±0.02ms     0.39  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 30}, {'x': 2})
-      49.9±0.3ms      19.1±0.06ms     0.38  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 30}, {'x': 2})
-     31.4±0.09ms      12.1±0.09ms     0.38  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 30}, {})
-     15.8±0.04ms       6.05±0.1ms     0.38  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 30}, {})
-     17.3±0.07ms      6.58±0.04ms     0.38  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 30}, {'x': 1})
-      37.7±0.1ms       14.4±0.1ms     0.38  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 30}, {'x': 1})
-      32.9±0.2ms      11.3±0.04ms     0.34  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 30}, {'x': 1})
-      43.9±0.2ms      15.1±0.02ms     0.34  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 30}, {'x': 2})
-     27.4±0.03ms      9.38±0.03ms     0.34  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 30}, {})
-     13.8±0.04ms      4.70±0.03ms     0.34  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 30}, {})
-     15.2±0.04ms      5.19±0.02ms     0.34  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 30}, {'x': 1})
-     16.6±0.07ms      5.67±0.02ms     0.34  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 30}, {'x': 2})
-     26.1±0.07ms      6.14±0.04ms     0.23  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 20}, {})
-      31.5±0.4ms      7.32±0.06ms     0.23  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 20}, {'x': 2})
-      62.6±0.2ms      14.5±0.07ms     0.23  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 20}, {'x': 1})
-     28.8±0.04ms      6.66±0.03ms     0.23  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 20}, {'x': 1})
-      83.6±0.3ms       19.2±0.1ms     0.23  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 20}, {'x': 2})
-      52.4±0.3ms       12.0±0.1ms     0.23  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 20}, {})
-      25.2±0.4ms      5.25±0.03ms     0.21  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 20}, {'x': 1})
-      72.6±0.6ms       15.1±0.1ms     0.21  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 20}, {'x': 2})
-      27.7±0.1ms      5.69±0.03ms     0.21  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 20}, {'x': 2})
-      45.7±0.5ms      9.37±0.08ms     0.20  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 20}, {})
-      55.2±0.2ms      11.3±0.03ms     0.20  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 20}, {'x': 1})
-     23.2±0.04ms      4.69±0.02ms     0.20  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 20}, {})
-         676±3ms        130±0.5ms     0.19  benchmarks.Generator.time_batch_concat_4d({'x': 5}, {'x': 10, 'y': 10}, True)
-       135±0.5ms      25.9±0.09ms     0.19  benchmarks.Generator.time_batch_concat_4d({'x': 5}, {'x': 10}, True)
-         1.50±0s        166±0.3ms     0.11  benchmarks.Generator.time_batch_concat_4d({'x': 5, 'y': 5}, {'x': 10}, True)
-       120±0.6ms       12.5±0.1ms     0.10  benchmarks.Generator.time_batch_concat_4d({'x': 5}, {'x': 10}, False)
-         1.02±0s        105±0.4ms     0.10  benchmarks.Generator.time_batch_concat_4d({'x': 5, 'y': 5}, {'x': 10}, False)
-         598±4ms       61.0±0.1ms     0.10  benchmarks.Generator.time_batch_concat_4d({'x': 5}, {'x': 10, 'y': 10}, False)
-      7.57±0.03s        224±0.4ms     0.03  benchmarks.Generator.time_batch_concat_4d({'x': 5, 'y': 5}, {'x': 10, 'y': 10}, True)
-      5.07±0.02s        104±0.5ms     0.02  benchmarks.Generator.time_batch_concat_4d({'x': 5, 'y': 5}, {'x': 10, 'y': 10}, False)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.

$ asv continuous 4d8e2c84a2d405e237f60f1df5286dd766e06ff0 batch-dims-bug
before           after         ratio
     [4d8e2c84]       [9d0fcb05]
     <v0.2.0~6>       <batch-dims-bug>
+     2.49±0.04ms       22.1±0.3ms     8.86  benchmarks.Generator.time_batch_preload(True)
+      32.6±0.4μs          111±1μs     3.41  benchmarks.TorchLoader.time_iterable_dataset
+      33.3±0.1μs        112±0.8μs     3.37  benchmarks.TorchLoader.time_map_dataset
+     4.93±0.02ms      7.32±0.06ms     1.48  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 30}, {'x': 2})
+     4.93±0.03ms      6.68±0.05ms     1.35  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 30}, {'x': 1})
+      14.2±0.1ms      19.1±0.07ms     1.34  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 30}, {'x': 2})
+     10.9±0.04ms      14.4±0.09ms     1.32  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 20}, {'x': 1})
+     5.60±0.07ms      7.26±0.02ms     1.30  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 20}, {'x': 2})
+     4.39±0.03ms      5.66±0.05ms     1.29  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 30}, {'x': 2})
+     11.3±0.06ms      14.4±0.04ms     1.28  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 30}, {'x': 1})
+     9.62±0.02ms       12.0±0.1ms     1.25  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 30}, {})
+     4.99±0.02ms      6.03±0.09ms     1.21  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 30}, {})
+        5.61±0ms      6.69±0.04ms     1.19  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {'x': 20}, {'x': 1})
+     9.58±0.04ms      11.3±0.01ms     1.18  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 20}, {'x': 1})
+     12.8±0.05ms      15.1±0.06ms     1.18  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 30}, {'x': 2})
+     4.39±0.04ms      5.18±0.06ms     1.18  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 30}, {'x': 1})
+      16.3±0.3ms      19.1±0.08ms     1.18  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 20}, {'x': 2})
+     5.26±0.04ms      6.13±0.01ms     1.17  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {}, {})
+     5.78±0.03ms      6.62±0.05ms     1.14  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {}, {'x': 1})
+      9.88±0.1ms      11.3±0.04ms     1.14  benchmarks.Generator.time_batch_input({'x': 5}, {'x': 30}, {'x': 1})
+     6.32±0.04ms      7.21±0.03ms     1.14  benchmarks.Generator.time_batch_input({'x': 10, 'y': 5}, {}, {'x': 2})
+      32.5±0.5ms       37.0±0.3ms     1.14  benchmarks.Accessor.time_accessor_input_dim({'x': 4, 'y': 2})
+     10.6±0.07ms      12.1±0.08ms     1.14  benchmarks.Generator.time_batch_concat({'x': 5, 'y': 5}, False)
+     16.6±0.05ms      18.9±0.07ms     1.14  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {}, {'x': 2})
+     5.04±0.06ms      5.70±0.03ms     1.13  benchmarks.Generator.time_batch_input({'x': 10}, {'x': 20}, {'x': 2})
+      65.0±0.3ms       73.5±0.2ms     1.13  benchmarks.Accessor.time_accessor_input_dim({'x': 2, 'y': 2})
+      10.6±0.1ms      12.0±0.04ms     1.12  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {}, {})
+      12.8±0.1ms      14.1±0.03ms     1.10  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {}, {'x': 1})
+      11.0±0.2ms       12.1±0.2ms     1.10  benchmarks.Generator.time_batch_input({'x': 5, 'y': 5}, {'x': 20}, {})

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.
```

To-Do:
- [x] Cherry pick commits not exclusively related to bug into one or more seperate PRs (https://github.com/xarray-contrib/xbatcher/pull/133)
- [x] Fix MyPy errors
- [x] Improve concat_input_dims implementation
- [x] Support dims being included in both batch_dims and input_dims
- [x] Resolve test that fails due to preload_batch being ignored
- [x] Examine benchmarks

Note - One test fails (marked with xfail) due to https://github.com/xarray-contrib/xbatcher/issues/126 which will be addressed separately

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

Fixes #131 
Fixes #121 
Fixes #30 
