### PR TITLE
Add tests for duplicate dims in batch_dims and input_dims

### DIFF
--- a/xbatcher/testing.py
+++ b/xbatcher/testing.py
@@ -55,7 +55,7 @@ def _get_non_input_batch_dims(generator: BatchGenerator) -> Dict[Hashable, int]:
 
 def _get_duplicate_batch_dims(generator: BatchGenerator) -> Dict[Hashable, int]:
     """
-    Return all dimensions that are in batch_dims as well as input_dims.
+    Return all dimensions that are in both batch_dims and input_dims.
 
     Parameters
     ----------
@@ -65,8 +65,7 @@ def _get_duplicate_batch_dims(generator: BatchGenerator) -> Dict[Hashable, int]:
     Returns
     -------
     d : dict
-        Dict containing all dimensions in specified in batch_dims that are
-        not also in input_dims
+        Dict containing all dimensions duplicated between batch_dims and input_dims.
     """
     return {
         dim: length

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -114,7 +114,7 @@ def test_batch_1d_concat(sample_ds_1d, input_size):
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
         assert "x" in ds_batch.coords
 
-
+@pytest.mark.xfail
 def test_batch_1d_concat_duplicate_dim(sample_ds_1d):
     """
     Test batch generation for a 1D dataset using ``concat_input_dims`` when

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -109,7 +109,7 @@ def test_batch_1d_concat(sample_ds_1d, input_size):
     )
     validate_generator_length(bg)
     expected_dims = get_batch_dimensions(bg)
-    for n, ds_batch in enumerate(bg):
+    for ds_batch in bg:
         assert isinstance(ds_batch, xr.Dataset)
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
         assert "x" in ds_batch.coords
@@ -163,7 +163,7 @@ def test_batch_1d_concat_no_coordinate(sample_ds_1d, input_size):
     )
     validate_generator_length(bg)
     expected_dims = get_batch_dimensions(bg)
-    for n, ds_batch in enumerate(bg):
+    for ds_batch in bg:
         assert isinstance(ds_batch, xr.Dataset)
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
         assert "x" not in ds_batch.coords
@@ -289,7 +289,7 @@ def test_batch_3d_2d_input_concat(sample_ds_3d, input_size):
     )
     validate_generator_length(bg)
     expected_dims = get_batch_dimensions(bg)
-    for n, ds_batch in enumerate(bg):
+    for ds_batch in bg:
         assert isinstance(ds_batch, xr.Dataset)
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
 
@@ -300,7 +300,7 @@ def test_batch_3d_2d_input_concat(sample_ds_3d, input_size):
     )
     validate_generator_length(bg)
     expected_dims = get_batch_dimensions(bg)
-    for n, ds_batch in enumerate(bg):
+    for ds_batch in bg:
         assert isinstance(ds_batch, xr.Dataset)
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
 

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -125,7 +125,7 @@ def test_batch_1d_concat_duplicate_dim(sample_ds_1d):
     )
     validate_generator_length(bg)
     expected_dims = get_batch_dimensions(bg)
-    for n, ds_batch in enumerate(bg):
+    for ds_batch in bg:
         assert isinstance(ds_batch, xr.Dataset)
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
 

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -115,6 +115,21 @@ def test_batch_1d_concat(sample_ds_1d, input_size):
         assert "x" in ds_batch.coords
 
 
+def test_batch_1d_concat_duplicate_dim(sample_ds_1d):
+    """
+    Test batch generation for a 1D dataset using ``concat_input_dims`` when
+    the same dimension occurs in ``input_dims`` and `batch_dims``
+    """
+    bg = BatchGenerator(
+        sample_ds_1d, input_dims={"x": 5}, batch_dims={"x": 10}, concat_input_dims=True
+    )
+    validate_generator_length(bg)
+    expected_dims = get_batch_dimensions(bg)
+    for n, ds_batch in enumerate(bg):
+        assert isinstance(ds_batch, xr.Dataset)
+        validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
+
+
 @pytest.mark.parametrize("input_size", [5, 10])
 def test_batch_1d_no_coordinate(sample_ds_1d, input_size):
     """
@@ -211,6 +226,23 @@ def test_batch_3d_1d_input_batch_dims(sample_ds_3d, concat):
         input_dims={"x": 5, "y": 10},
         batch_dims={"time": 2},
         concat_input_dims=concat,
+    )
+    validate_generator_length(bg)
+    expected_dims = get_batch_dimensions(bg)
+    for ds_batch in bg:
+        validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
+
+
+def test_batch_3d_1d_input_batch_concat_duplicate_dim(sample_ds_3d):
+    """
+    Test batch generation for a 3D dataset using ``concat_input_dims`` when
+    the same dimension occurs in ``input_dims`` and batch_dims``.
+    """
+    bg = BatchGenerator(
+        sample_ds_3d,
+        input_dims={"x": 5, "y": 10},
+        batch_dims={"x": 10, "y": 20},
+        concat_input_dims=True,
     )
     validate_generator_length(bg)
     expected_dims = get_batch_dimensions(bg)

--- a/xbatcher/tests/test_generators.py
+++ b/xbatcher/tests/test_generators.py
@@ -114,7 +114,10 @@ def test_batch_1d_concat(sample_ds_1d, input_size):
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
         assert "x" in ds_batch.coords
 
-@pytest.mark.xfail
+
+@pytest.mark.xfail(
+    reason="Bug described in https://github.com/xarray-contrib/xbatcher/issues/131"
+)
 def test_batch_1d_concat_duplicate_dim(sample_ds_1d):
     """
     Test batch generation for a 1D dataset using ``concat_input_dims`` when
@@ -216,6 +219,9 @@ def test_batch_3d_1d_input(sample_ds_3d, input_size):
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
 
 
+@pytest.mark.xfail(
+    reason="Bug described in https://github.com/xarray-contrib/xbatcher/issues/131"
+)
 @pytest.mark.parametrize("concat", [True, False])
 def test_batch_3d_1d_input_batch_dims(sample_ds_3d, concat):
     """
@@ -233,6 +239,9 @@ def test_batch_3d_1d_input_batch_dims(sample_ds_3d, concat):
         validate_batch_dimensions(expected_dims=expected_dims, batch=ds_batch)
 
 
+@pytest.mark.xfail(
+    reason="Bug described in https://github.com/xarray-contrib/xbatcher/issues/131"
+)
 def test_batch_3d_1d_input_batch_concat_duplicate_dim(sample_ds_3d):
     """
     Test batch generation for a 3D dataset using ``concat_input_dims`` when


### PR DESCRIPTION
**Description of proposed changes**

This PR adds two tests for BatchGenerator when there are one or more dimensions included in both input_dims and batch_dims. The testing utilities are updated to account for this case. The tests currently fail due to https://github.com/xarray-contrib/xbatcher/issues/131, but including them will be helpful for finishing #132.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

