### PR TITLE
Iterate through batch generator in benchmarks 

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -52,7 +52,11 @@ class Generator(Base):
         batches.
         """
         ds_dask = self.ds_2d.chunk({"sample": 2})
-        BatchGenerator(ds_dask, input_dims={"sample": 2}, preload_batch=preload_batch)
+        bg = BatchGenerator(
+            ds_dask, input_dims={"sample": 2}, preload_batch=preload_batch
+        )
+        for batch in bg:
+            pass
 
     @parameterized(
         ["input_dims", "batch_dims", "input_overlap"],
@@ -66,12 +70,14 @@ class Generator(Base):
         """
         Benchmark simple batch generation case.
         """
-        BatchGenerator(
+        bg = BatchGenerator(
             self.ds_3d,
             input_dims=input_dims,
             batch_dims=batch_dims,
             input_overlap=input_overlap,
         )
+        for batch in bg:
+            pass
 
     @parameterized(
         ["input_dims", "concat_input_dims"],
@@ -82,11 +88,13 @@ class Generator(Base):
         Construct a generator on a DataSet with and without concatenating
         chunks specified by ``input_dims`` into the batch dimension.
         """
-        BatchGenerator(
+        bg = BatchGenerator(
             self.ds_3d,
             input_dims=input_dims,
             concat_input_dims=concat_input_dims,
         )
+        for batch in bg:
+            pass
 
     @parameterized(
         ["input_dims", "batch_dims", "concat_input_dims"],
@@ -101,12 +109,14 @@ class Generator(Base):
         Construct a generator on a DataSet with and without concatenating
         chunks specified by ``input_dims`` into the batch dimension.
         """
-        BatchGenerator(
+        bg = BatchGenerator(
             self.ds_4d,
             input_dims=input_dims,
             batch_dims=batch_dims,
             concat_input_dims=concat_input_dims,
         )
+        for batch in bg:
+            pass
 
 
 class Accessor(Base):
@@ -119,7 +129,9 @@ class Accessor(Base):
         Benchmark simple batch generation case using xarray accessor
         Equivalent to subset of ``time_batch_input()``.
         """
-        self.ds_3d.batch.generator(input_dims=input_dims)
+        bg = self.ds_3d.batch.generator(input_dims=input_dims)
+        for batch in bg:
+            pass
 
 
 class TorchLoader(Base):

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -24,16 +24,16 @@ class Base:
         shape_4d = (10, 50, 100, 3)
         self.ds_4d = xr.Dataset(
             {
-                "foo": (["time", "y", "x", "b"], np.random.rand(*shape_4d)),
+                "foo": (["time", "y", "x", "z"], np.random.rand(*shape_4d)),
             },
             {
                 "x": (["x"], np.arange(shape_4d[-2])),
                 "y": (["y"], np.arange(shape_4d[-3])),
-                "b": (["b"], np.arange(shape_4d[-1])),
+                "z": (["z"], np.arange(shape_4d[-1])),
             },
         )
 
-        self.ds_xy = xr.Dataset(
+        self.ds_2d = xr.Dataset(
             {
                 "x": (
                     ["sample", "feature"],
@@ -51,7 +51,7 @@ class Generator(Base):
         Construct a generator on a chunked DataSet with and without preloading
         batches.
         """
-        ds_dask = self.ds_xy.chunk({"sample": 2})
+        ds_dask = self.ds_2d.chunk({"sample": 2})
         BatchGenerator(ds_dask, input_dims={"sample": 2}, preload_batch=preload_batch)
 
     @parameterized(
@@ -125,8 +125,8 @@ class Accessor(Base):
 class TorchLoader(Base):
     def setup(self, *args, **kwargs):
         super().setup(**kwargs)
-        self.x_gen = BatchGenerator(self.ds_xy["x"], {"sample": 10})
-        self.y_gen = BatchGenerator(self.ds_xy["y"], {"sample": 10})
+        self.x_gen = BatchGenerator(self.ds_2d["x"], {"sample": 10})
+        self.y_gen = BatchGenerator(self.ds_2d["y"], {"sample": 10})
 
     def time_map_dataset(self):
         """
@@ -134,7 +134,7 @@ class TorchLoader(Base):
         """
         dataset = MapDataset(self.x_gen, self.y_gen)
         loader = torch.utils.data.DataLoader(dataset)
-        iter(loader).next()
+        next(iter(loader))
 
     def time_iterable_dataset(self):
         """
@@ -142,4 +142,4 @@ class TorchLoader(Base):
         """
         dataset = IterableDataset(self.x_gen, self.y_gen)
         loader = torch.utils.data.DataLoader(dataset)
-        iter(loader).next()
+        next(iter(loader))


### PR DESCRIPTION
**Description of proposed changes**

In this PR the benchmarks iterate through the batch generator for a more complete evaluation of performance now that batch generation is lazy. Further improvements could include separate metrics for creating the batch selectors versus indexing on batches, but this is a step forward.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

Fixes #
