### PR TITLE
Update packaging configuration and workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,12 +58,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - run: |
           python -m pip install -e .[dev]
           python -m pip install --no-deps --upgrade \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,10 @@ on:
     branches: main
   pull_request:
     branches: main
+    paths-ignore:
+      - ".github/workflows/*-release.yaml"
+      - "asv_bench/**"
+      - "doc/**"
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -4,9 +4,9 @@ on:
     types:
       - published
   # Runs for pull requests should be disabled other than for testing purposes
-  pull_request:
-    branches:
-      - main
+  #pull_request:
+  #  branches:
+  #    - main
 
 permissions:
   contents: read

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -36,7 +36,7 @@ jobs:
           # Change setuptools-scm local_scheme to "no-local-version" so the
           # local part of the version isn't included, making the version string
           # compatible with PyPI.
-          sed --in-place "s/dirty-tag/no-local-version/g" pyproject.toml
+          sed --in-place "s/node-and-date/no-local-version/g" pyproject.toml
 
       - name: Build tarball and wheels
         run: |

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -3,6 +3,10 @@ on:
   release:
     types:
       - published
+  # Runs for pull requests should be disabled other than for testing purposes
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -1,8 +1,11 @@
-name: Build and Upload xbatcher to PyPI
+name: Build and Upload xbatcher to TestPyPI
 on:
-  release:
-    types:
-      - published
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -15,6 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - uses: actions/setup-python@v4.4.0
         name: Install Python
         with:
@@ -70,29 +74,16 @@ jobs:
         run: |
           ls -ltrh
           ls -ltrh dist
+
       - name: Verify the built dist/wheel is valid
         run: |
           python -m pip install --upgrade pip
           python -m pip install dist/xbatcher*.whl
           python -m xbatcher.util.print_versions
+
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
-          # verbose: true
-
-  upload-to-pypi:
-    needs: test-built-dist
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: releases
-          path: dist
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.6.4
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           # verbose: true

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -34,8 +34,8 @@ jobs:
       - name: Fix up version string for TestPyPI
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
-          sed --in-place "/version_scheme/d" pyproject.toml
-          sed --in-place "s/dirty-tag/no-local-version/g" pyproject.toml
+          sed --in-place "s/node-and-date/no-local-version/g" pyproject.toml
+          git update-index --assume-unchanged pyproject.toml
 
       - name: Build tarball and wheels
         run: |

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -35,7 +35,6 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
           sed --in-place "s/node-and-date/no-local-version/g" pyproject.toml
-          git update-index --assume-unchanged pyproject.toml
 
       - name: Build tarball and wheels
         run: |

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install build twine
+          pip list
 
       - name: Fix up version string for TestPyPI
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
@@ -38,7 +39,6 @@ jobs:
 
       - name: Build tarball and wheels
         run: |
-          cat pyproject.toml
           python -m build
           echo "Generated files:"
           ls -lh dist/

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -34,13 +34,12 @@ jobs:
       - name: Fix up version string for TestPyPI
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
-          # Change setuptools-scm local_scheme to "no-local-version" so the
-          # local part of the version isn't included, making the version string
-          # compatible with PyPI.
+          sed --in-place "/version_scheme/d" pyproject.toml
           sed --in-place "s/dirty-tag/no-local-version/g" pyproject.toml
 
       - name: Build tarball and wheels
         run: |
+          cat pyproject.toml
           python -m build
           echo "Generated files:"
           ls -lh dist/

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -11,9 +11,11 @@ permissions:
   contents: read
 
 jobs:
-  build-artifacts:
+  publish-testpypi:
+    name: Publish to Test PyPI
     runs-on: ubuntu-latest
     if: github.repository == 'xarray-contrib/xbatcher'
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -22,31 +24,26 @@ jobs:
       - uses: actions/setup-python@v4.4.0
         name: Install Python
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install build twine
 
-      - name: Cleanup repository
-        run: |
-          git clean -xdf
-          git restore -SW .
-
-      # This step is only necessary for testing purposes and for TestPyPI
       - name: Fix up version string for TestPyPI
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
           # Change setuptools-scm local_scheme to "no-local-version" so the
           # local part of the version isn't included, making the version string
           # compatible with PyPI.
-          sed --in-place "/version_scheme/d" pyproject.toml
           sed --in-place "s/dirty-tag/no-local-version/g" pyproject.toml
 
       - name: Build tarball and wheels
         run: |
           python -m build
+          echo "Generated files:"
+          ls -lh dist/
 
       - name: Check built artifacts
         run: |
@@ -58,27 +55,6 @@ jobs:
           else
             echo "✅ Looks good"
           fi
-      - uses: actions/upload-artifact@v3
-        with:
-          name: releases
-          path: dist
-
-  test-built-dist:
-    needs: build-artifacts
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v4.4.0
-        name: Install Python
-        with:
-          python-version: 3.8
-      - uses: actions/download-artifact@v3
-        with:
-          name: releases
-          path: dist
-      - name: List contents of built dist
-        run: |
-          ls -ltrh
-          ls -ltrh dist
 
       - name: Verify the built dist/wheel is valid
         run: |

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -36,6 +36,7 @@ jobs:
           # Change setuptools-scm local_scheme to "no-local-version" so the
           # local part of the version isn't included, making the version string
           # compatible with PyPI.
+          sed --in-place "/version_scheme/d" pyproject.toml
           sed --in-place "s/dirty-tag/no-local-version/g" pyproject.toml
 
       - name: Build tarball and wheels

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -29,6 +29,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install build twine
 
+      - name: Cleanup repository
+        run: |
+          git clean -xdf
+          git restore -SW .
+
       # This step is only necessary for testing purposes and for TestPyPI
       - name: Fix up version string for TestPyPI
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
@@ -41,9 +46,8 @@ jobs:
 
       - name: Build tarball and wheels
         run: |
-          git clean -xdf
-          git restore -SW .
           python -m build
+
       - name: Check built artifacts
         run: |
           python -m twine check --strict dist/*

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           python -m pip install build twine
 
       - name: Fix up version string for TestPyPI

--- a/.github/workflows/testpypi-release.yaml
+++ b/.github/workflows/testpypi-release.yaml
@@ -17,19 +17,19 @@ jobs:
     if: github.repository == 'xarray-contrib/xbatcher'
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3.2.0
         with:
+          # fetch all history so that setuptools-scm works
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4.4.0
-        name: Install Python
+      - name: Set up Python
+        uses: actions/setup-python@v4.3.1
         with:
           python-version: "3.10"
 
       - name: Install dependencies
-        run: |
-          python -m pip install build twine
-          pip list
+        run: python -m pip install build
 
       - name: Fix up version string for TestPyPI
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
@@ -42,17 +42,6 @@ jobs:
           python -m build
           echo "Generated files:"
           ls -lh dist/
-
-      - name: Check built artifacts
-        run: |
-          python -m twine check --strict dist/*
-          pwd
-          if [ -f dist/xbatcher-0.0.0.tar.gz ]; then
-            echo "❌ INVALID VERSION NUMBER"
-            exit 1
-          else
-            echo "✅ Looks good"
-          fi
 
       - name: Verify the built dist/wheel is valid
         run: |

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Or from source as::
    for more details.
 
 Documentation
-------------
+-------------
 
 Documentation is hosted on ReadTheDocs: https://xbatcher.readthedocs.org
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,7 @@ repository = "https://github.com/xarray-contrib/xbatcher"
 include = ["xbatcher*"]
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
-local_scheme = "dirty-tag"
+local_scheme = "node-and-date"
 fallback_version = "999"
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=61",
-    "setuptools-scm"
+    "setuptools>=64",
+    "setuptools-scm[toml]>=6.2"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ fallback_version = "999"
 
 [tool.isort]
 profile = "black"
-known_third_party = ["numpy", "pytest", "setuptools", "sphinx_autosummary_accessors", "torch", "xarray"]
+known_third_party = ["numpy", "pytest", "sphinx_autosummary_accessors", "torch", "xarray"]
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from setuptools import setup
-
-setup(use_scm_version={"fallback_version": "999"})


### PR DESCRIPTION
**Description of proposed changes**

- Upload to TestPyPI on push to main
- Remove setup.py, which is not needed for setuptools>=64.0.0
- Fix readme syntax
- Use `local_scheme = "node-and-date"`
<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

Fixes #
