### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@v4.5.0
         name: Install Python
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Install dependencies
         run: |
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/setup-python@v4.5.0
         name: Install Python
         with:
-          python-version: 3.8
+          python-version: 3.10
       - uses: actions/download-artifact@v3
         with:
           name: releases

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black-jupyter
 
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.8
+  - python=3.9
   - dask
   - pydata-sphinx-theme
   - ipython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "Batch generation from Xarray objects"
 readme = "README.rst"
 license = {text = "Apache"}
 authors = [{name = "xbatcher Developers", email = "rpa@ldeo.columbia.edu"}]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: Apache Software License",
@@ -19,7 +19,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering",

--- a/xbatcher/generators.py
+++ b/xbatcher/generators.py
@@ -380,7 +380,6 @@ class BatchGenerator:
         concat_input_dims: bool = False,
         preload_batch: bool = True,
     ):
-
         self.ds = ds
         self._batch_selectors: BatchSchema = BatchSchema(
             ds,
@@ -419,7 +418,6 @@ class BatchGenerator:
         return len(self._batch_selectors.selectors)
 
     def __getitem__(self, idx: int) -> Union[xr.Dataset, xr.DataArray]:
-
         if not isinstance(idx, int):
             raise NotImplementedError(
                 f"{type(self).__name__}.__getitem__ currently requires a single integer key"
@@ -429,7 +427,6 @@ class BatchGenerator:
             idx = list(self._batch_selectors.selectors)[idx]
 
         if idx in self._batch_selectors.selectors:
-
             if self.concat_input_dims:
                 new_dim_suffix = "_input"
                 all_dsets: List = []

--- a/xbatcher/tests/test_keras_loaders.py
+++ b/xbatcher/tests/test_keras_loaders.py
@@ -25,7 +25,6 @@ def ds_xy():
 
 
 def test_custom_dataarray(ds_xy):
-
     x = ds_xy["x"]
     y = ds_xy["y"]
 
@@ -46,7 +45,6 @@ def test_custom_dataarray(ds_xy):
 
 
 def test_custom_dataarray_with_transform(ds_xy):
-
     x = ds_xy["x"]
     y = ds_xy["y"]
 

--- a/xbatcher/tests/test_torch_loaders.py
+++ b/xbatcher/tests/test_torch_loaders.py
@@ -32,7 +32,6 @@ def ds_xy():
     ],
 )
 def test_map_dataset(ds_xy, x_var, y_var):
-
     x = ds_xy[x_var]
     y = ds_xy[y_var]
 
@@ -85,7 +84,6 @@ def test_map_dataset(ds_xy, x_var, y_var):
     ],
 )
 def test_map_dataset_with_transform(ds_xy, x_var, y_var):
-
     x = ds_xy[x_var]
     y = ds_xy[y_var]
 
@@ -117,7 +115,6 @@ def test_map_dataset_with_transform(ds_xy, x_var, y_var):
     ],
 )
 def test_iterable_dataset(ds_xy, x_var, y_var):
-
     x = ds_xy[x_var]
     y = ds_xy[y_var]
 


### PR DESCRIPTION
**Description of proposed changes**

Drop Python 3.8 since it's no longer supported by Xarray (https://github.com/pydata/xarray/pull/7461)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

Fixes #
