### PR TITLE
WIP: DataTree slice generator function 

### DIFF
--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - pytest-cov
   - pytorch
   - tensorflow
+  - xarray-datatree
   - zarr
   # Style checks
   - black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ fallback_version = "999"
 
 [tool.isort]
 profile = "black"
-known_third_party = ["numpy", "pandas", "pytest", "sphinx_autosummary_accessors", "torch", "xarray"]
+known_third_party = ["datatree", "numpy", "pandas", "pytest", "sphinx_autosummary_accessors", "torch", "xarray"]
 
 [tool.pytest.ini_options]
 log_cli = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "xarray",
 ]
 [project.optional-dependencies]
+datatree = ["xarray-datatree"]
 torch = [
     "torch",
 ]

--- a/xbatcher/__init__.py
+++ b/xbatcher/__init__.py
@@ -3,7 +3,11 @@ from importlib.metadata import version as _version
 
 from . import testing  # noqa: F401
 from .accessors import BatchAccessor  # noqa: F401
-from .generators import BatchGenerator, BatchSchema  # noqa: F401
+from .generators import (  # noqa: F401
+    BatchGenerator,
+    BatchSchema,
+    datatree_slice_generator,
+)
 from .util.print_versions import show_versions  # noqa: F401
 
 try:

--- a/xbatcher/tests/test_datatree.py
+++ b/xbatcher/tests/test_datatree.py
@@ -1,0 +1,80 @@
+import datatree.testing as dtt
+import numpy as np
+import pytest
+import xarray as xr
+from datatree import DataTree
+
+from xbatcher import datatree_slice_generator
+
+
+@pytest.fixture(scope="module")
+def sample_datatree() -> DataTree:
+    """
+    Sample multi-resolution DataTree for testing.
+
+    DataTree('None', parent=None)
+    ├── DataTree('grid10m')
+    │       Dimensions:  (y: 4, x: 6)
+    │       Coordinates:
+    │         * y        (y) float64 40.0 30.0 20.0 10.0
+    │         * x        (x) float64 100.0 110.0 120.0 130.0 140.0 150.0
+    │       Data variables:
+    │           grid10m  (y, x) int64 10 11 12 13 14 15 16 17 18 ... 26 27 28 29 30 31 32 33
+    └── DataTree('grid20m')
+            Dimensions:  (y: 2, x: 3)
+            Coordinates:
+              * y        (y) float64 35.0 15.0
+              * x        (x) float64 105.0 125.0 145.0
+            Data variables:
+                grid20m  (y, x) int64 0 1 2 3 4 5
+    """
+    grid20m = xr.DataArray(
+        data=np.arange(0, 6).reshape(2, 3),
+        dims=("y", "x"),
+        coords={"y": np.linspace(35.0, 15.0, num=2), "x": np.linspace(105, 145, num=3)},
+        name="grid20m",
+    )
+    grid10m = xr.DataArray(
+        data=np.arange(10, 34).reshape(4, 6),
+        dims=("y", "x"),
+        coords={"y": np.linspace(40.0, 10.0, num=4), "x": np.linspace(100, 150, num=6)},
+        name="grid10m",
+    )
+    dt = DataTree.from_dict(d={"grid10m": grid10m, "grid20m": grid20m})
+    return dt
+
+
+@pytest.fixture(scope="module")
+def expected_datatree() -> DataTree:
+    """ """
+    expected_datatree = DataTree.from_dict(
+        d={
+            "grid10m": xr.DataArray(
+                data=[[26, 27], [32, 33]],
+                dims=("y", "x"),
+                coords={"y": [20.0, 10.0], "x": [140.0, 150.0]},
+                name="grid10m",
+            ),
+            "grid20m": xr.DataArray(
+                data=[[5]],
+                dims=("y", "x"),
+                coords={"y": [15.0], "x": [145.0]},
+                name="grid20m",
+            ),
+        }
+    )
+    return expected_datatree
+
+
+def test_datatree(sample_datatree, expected_datatree):
+    """
+    Test slicing through a multi-resolution DataTree.
+    """
+    generator = datatree_slice_generator(
+        data_obj=sample_datatree, dim_strides={"y": -20, "x": 20}, ref_node="grid20m"
+    )
+    for i, chip in enumerate(generator):
+        pass
+
+    assert i + 1 == 6  # number of chips
+    dtt.assert_identical(a=chip, b=expected_datatree)  # check returned DataTree


### PR DESCRIPTION
**Description of proposed changes**

Very experimental proof of concept to generate subsets out of a multi-resolution [DataTree](https://github.com/xarray-contrib/datatree). Do we call the subsets DataBranch :thinking:?

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Initial implementation is using a standalone function rather than re-using anything from 

TODO:
- [ ] Add more unit tests, a lot more
- [ ] Refactor to use some of the BatchSchema code from https://github.com/xarray-contrib/xbatcher/blob/v0.3.0/xbatcher/generators.py?
  - Actually thinking it might be nice to separate the slicing from the batching, akin to torchdata's [`Slicer`](https://pytorch.org/data/0.6/generated/torchdata.datapipes.iter.Slicer.html) and [`Batcher`](https://pytorch.org/data/0.6/generated/torchdata.datapipes.iter.Batcher.html) , will open separate issue
- [ ] Provide an inline example/doctest
- [ ] etc

References (some of the complicated for-loops chip generators I've written over the years :see_no_evil:):
- https://github.com/weiji14/deepbedmap/blame/v1.1.0/data_prep.py#L497-L741
- https://github.com/weiji14/s2s2net/blob/4bd176a9a5eb002709a017186e81a8f02898e48b/s2s2net/data_chipper.py#L36-L37

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

Fixes #93