### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "Batch generation from Xarray objects"
 readme = "README.rst"
 license = {text = "Apache"}
 authors = [{name = "xbatcher Developers", email = "rpa@ldeo.columbia.edu"}]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: Apache Software License",
@@ -19,7 +19,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -62,7 +61,7 @@ fallback_version = "999"
 
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 extend-include = ["*.ipynb"]
 
 

--- a/xbatcher/accessors.py
+++ b/xbatcher/accessors.py
@@ -1,11 +1,11 @@
-from typing import Any, Union
+from typing import Any
 
 import xarray as xr
 
 from .generators import BatchGenerator
 
 
-def _as_xarray_dataarray(xr_obj: Union[xr.Dataset, xr.DataArray]) -> xr.DataArray:
+def _as_xarray_dataarray(xr_obj: xr.Dataset | xr.DataArray) -> xr.DataArray:
     """
     Convert xarray.Dataset to xarray.DataArray if needed, so that it can
     be converted into a Tensor object.
@@ -19,7 +19,7 @@ def _as_xarray_dataarray(xr_obj: Union[xr.Dataset, xr.DataArray]) -> xr.DataArra
 @xr.register_dataarray_accessor('batch')
 @xr.register_dataset_accessor('batch')
 class BatchAccessor:
-    def __init__(self, xarray_obj: Union[xr.Dataset, xr.DataArray]):
+    def __init__(self, xarray_obj: xr.Dataset | xr.DataArray):
         """
         Batch accessor returning a BatchGenerator object via the `generator method`
         """
@@ -42,7 +42,7 @@ class BatchAccessor:
 @xr.register_dataarray_accessor('tf')
 @xr.register_dataset_accessor('tf')
 class TFAccessor:
-    def __init__(self, xarray_obj: Union[xr.Dataset, xr.DataArray]):
+    def __init__(self, xarray_obj: xr.Dataset | xr.DataArray):
         self._obj = xarray_obj
 
     def to_tensor(self) -> Any:
@@ -57,7 +57,7 @@ class TFAccessor:
 @xr.register_dataarray_accessor('torch')
 @xr.register_dataset_accessor('torch')
 class TorchAccessor:
-    def __init__(self, xarray_obj: Union[xr.Dataset, xr.DataArray]):
+    def __init__(self, xarray_obj: xr.Dataset | xr.DataArray):
         self._obj = xarray_obj
 
     def to_tensor(self) -> Any:

--- a/xbatcher/loaders/keras.py
+++ b/xbatcher/loaders/keras.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 try:
     import tensorflow as tf
@@ -21,8 +22,8 @@ class CustomTFDataset(tf.keras.utils.Sequence):
         X_generator,
         y_generator,
         *,
-        transform: Optional[Callable] = None,
-        target_transform: Optional[Callable] = None,
+        transform: Callable | None = None,
+        target_transform: Callable | None = None,
     ) -> None:
         """
         Keras Dataset adapter for Xbatcher

--- a/xbatcher/loaders/torch.py
+++ b/xbatcher/loaders/torch.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 try:
     import torch
@@ -24,8 +25,8 @@ class MapDataset(torch.utils.data.Dataset):
         self,
         X_generator,
         y_generator,
-        transform: Optional[Callable] = None,
-        target_transform: Optional[Callable] = None,
+        transform: Callable | None = None,
+        target_transform: Callable | None = None,
     ) -> None:
         """
         PyTorch Dataset adapter for Xbatcher

--- a/xbatcher/testing.py
+++ b/xbatcher/testing.py
@@ -1,5 +1,4 @@
 from collections.abc import Hashable
-from typing import Union
 from unittest import TestCase
 
 import numpy as np
@@ -170,7 +169,7 @@ def get_batch_dimensions(generator: BatchGenerator) -> dict[Hashable, int]:
 
 
 def validate_batch_dimensions(
-    *, expected_dims: dict[Hashable, int], batch: Union[xr.Dataset, xr.DataArray]
+    *, expected_dims: dict[Hashable, int], batch: xr.Dataset | xr.DataArray
 ) -> None:
     """
     Raises an AssertionError if the shape and dimensions of a batch do not


### PR DESCRIPTION
**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). GitHub will automatically close it when this gets merged. -->

- Now that xarray has officially dropped supprt for Python 3.9: https://github.com/pydata/xarray/pull/8937, this PR bumps the required/minimum Python version to 3.10
- Closes #230
